### PR TITLE
Fix Twitter and Mesh extension links

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,8 +227,8 @@
                         </a>
                         <section class="description">
                             <p>Broadcast messages to other projects!</p>
-                            <a href="?url=http://technoboy10.tk/mesh/mesh.sbx" data-action="load-url">Sample Project</a>
-                            <a href="http://technoboy10.tk/mesh/" target="_blank">Documentation</a>
+                            <a href="?url=http://technoboy10.github.io/mesh/mesh.sbx" data-action="load-url">Sample Project</a>
+                            <a href="http://technoboy10.github.io/mesh/" target="_blank">Documentation</a>
                         </section>
                         <section class="tags">
                             <span class="tag web" title="Web Extension">Requires Internet Connection</span>
@@ -516,8 +516,8 @@
                         </a>
                         <section class="description">
                             <p>Use Twitter in your projects!</p>
-                            <a href="?url=http://technoboy10.tk/twitter/examples/Fetch%20a%20Tweet.sbx" data-action="load-url">Sample Project</a>
-                            <a href="http://technoboy10.tk/twitter/" target="_blank">Documentation</a>
+                            <a href="?url=http://technoboy10.github.io/twitter/examples/Fetch%20a%20Tweet.sbx" data-action="load-url">Sample Project</a>
+                            <a href="http://technoboy10.github.io/twitter/" target="_blank">Documentation</a>
                         </section>
                         <section class="tags">
                             <span class="tag web" title="Web Extension">Requires Internet Connection</span>


### PR DESCRIPTION
My site is no longer at technoboy10.tk, so the Twitter and Firebase Mesh sample projects and extensions stopped working. This PR changes the domain of those extensions to the correct one, technoboy10.github.io.