### PR TITLE
Add an alt attribute to all extension thumbnails | Fixes #138

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
             <ul class="featured-extensions">
                 <li class="featured-extension">
                     <a href="https://ericrosenbaum.github.io/spotify-extension/">
-                        <img src="images/extensions/spotify_large.png" />
+                        <img src="images/extensions/spotify_large.png" alt="Spotify" />
                         <section>
                             <h2>Spotify</h2>
                             <p class="author">Eric Rosenbaum</p>
@@ -46,7 +46,7 @@
                 </li>
                 <li class="featured-extension">
                     <a href="https://llk.github.io/microbit-extension/">
-                        <img src="images/extensions/microbit_small.png" />
+                        <img src="images/extensions/microbit_small.png" alt="micro:bit" />
                         <section>
                             <h2>micro:bit</h2>
                             <p class="author">Kreg Hanning</p>
@@ -55,7 +55,7 @@
                 </li>
                 <li class="featured-extension">
                     <a href="?url=http://scratchx.org/tmp/TalkingGobo.sbx" data-action="load-url">
-                        <img src="images/extensions/text-extension-sm.png" />
+                        <img src="images/extensions/text-extension-sm.png" alt="Text To Speech" />
                         <section>
                             <h2>Text to Speech</h2>
                             <p class="author">Sayamindu Dasgupta</p>
@@ -64,7 +64,7 @@
                 </li>
                 <li class="featured-extension">
                     <a href="https://khanning.github.io/scratch-arduino-extension/">
-                        <img src="images/extensions/arduino_small.png" />
+                        <img src="images/extensions/arduino_small.png" alt="Arduino" />
                         <section>
                             <h2>Arduino</h2>
                             <p class="author">Kreg Hanning, David Mellis</p>
@@ -88,7 +88,7 @@
                 <div>
                     <div>
                         <h2 class="logo-scratch">Scratch</h2>
-                        <p>With the Scratch programming language, you can create your own interactive stories, games, and animations &mdash; and share your creations with others in an online community. <a href="http://scratch.mit.edu/">Take me to Scratch</a></p>
+                        <p>With the Scratch programming language, you can create your own interactive stories, games, and animations &mdash; and share your creations with others in an online community. <a href="http://scratch.mit.edu">Take me to Scratch</a></p>
                     </div>
                 </div>
                 <div>
@@ -138,7 +138,7 @@
                                 <h2>Arduino</h2>
                                 <p class="author">Kreg Hanning, David Mellis</p>
                             </header>
-                            <img src="images/extensions/arduino_small.png" />
+                            <img src="images/extensions/arduino_small.png" alt="Arduino" />
                         </a>
                         <section class="description">
                             <p>Control Arduino boards</p>
@@ -172,7 +172,7 @@
                                 <h2>Clarifai</h2>
                                 <p class="author">Stefania Druga &amp; Eesh Likhith</p>
                             </header>
-                            <img src="images/extensions/clarifai_small.png" />
+                            <img src="images/extensions/clarifai_small.png" alt="Clarifai" />
                         </a>
                         <section class="description">
                             <p>Recognize images from your webcam.</p>
@@ -189,7 +189,7 @@
                                 <h2>EV3+Scratch</h2>
                                 <p class="author">Ken Aspeslagh</p>
                             </header>
-                            <img src="images/extensions/ev3_small.png" />
+                            <img src="images/extensions/ev3_small.png" alt="EV3+Scratch" />
                         </a>
                         <section class="description">
                             <p>Control LEGO EV3 robots wirelessly</p>
@@ -206,7 +206,7 @@
                                 <h2>EV3+Scratch (Hebrew Version)</h2>
                                 <p class="author">Robotec Israel</p>
                             </header>
-                            <img src="images/extensions/robotec_small.png" />
+                            <img src="images/extensions/robotec_small.png" alt="EV3+Scratch (Hebrew Version)" />
                         </a>
                         <section class="description">
                             <p>Control LEGO EV3 over USB (Hebrew)</p>
@@ -223,7 +223,7 @@
                                 <h2>Firebase Mesh</h2>
                                 <p class="author">Connor Hudson</p>
                             </header>
-                            <img src="images/extensions/mesh-extension-sm.png" />
+                            <img src="images/extensions/mesh-extension-sm.png" alt="Firebase Mesh" />
                         </a>
                         <section class="description">
                             <p>Broadcast messages to other projects!</p>
@@ -240,7 +240,7 @@
                                 <h2>Fischertechnik robots</h2>
                                 <p class="author">Fischertechnik Israel</p>
                             </header>
-                            <img src="images/extensions/fischertechnik-extension-sm.png" />
+                            <img src="images/extensions/fischertechnik-extension-sm.png" alt="Fischertechnik robots" />
                         </a>
                         <section class="description">
                             <p>TXT controller programming (Hebrew)</p>
@@ -257,7 +257,7 @@
                                 <h2>Intel&reg; RealSense&trade;</h2>
                                 <p class="author">Shachar Oz, Yaron Yanai, Yotam Salmon</p>
                             </header>
-                            <img src="images/extensions/realsense_small.png" />
+                            <img src="images/extensions/realsense_small.png" alt="ischertechnik robots" />
                         </a>
                         <section class="description">
                             <p>Hand Gestures, face tracking, voice commands</p>
@@ -269,12 +269,12 @@
                         </section>
                     </li>
                     <li>
-                        <a href="?url=https://irobotstem.github.io/CreateScratchX/roomba600Extension.js" data-action="load-url">
+                        <a href="?url=https://irobotstem.github.io/CreateScratchX/roomba600Extension.js" data-action="load-url"> 
                             <header>
                                 <h2>iRobot&reg; Create&reg; 2</h2>
                                 <p class="author">iRobot</p>
                             </header>
-                            <img src="images/extensions/iRobot_small.png" />
+                            <img src="images/extensions/iRobot_small.png" alt="iRobot® Create® 2" />
                         </a>
                         <section class="description">
                             <p>Control iRobot&reg; Create&reg; 2</p>
@@ -291,7 +291,7 @@
                                 <h2>ISS Tracker</h2>
                                 <p class="author">Kreg Hanning</p>
                             </header>
-                            <img src="images/extensions/ISSTracker_small.png" />
+                            <img src="images/extensions/ISSTracker_small.png" alt="ISS Tracker" />
                         </a>
                         <section class="description">
                             <p>International Space Station tracker</p>
@@ -308,7 +308,7 @@
                                 <h2>Leapmotion</h2>
                                 <p class="author">Kreg Hanning</p>
                             </header>
-                            <img src="images/extensions/leapmotion_small.png" />
+                            <img src="images/extensions/leapmotion_small.png" alt="Leapmotion" />
                         </a>
                         <section class="description">
                             <p>Hand and finger tracking</p>
@@ -325,7 +325,7 @@
                                 <h2>littleBits</h2>
                                 <p class="author">Kreg Hanning</p>
                             </header>
-                            <img src="images/extensions/littlebits_small.jpg" />
+                            <img src="images/extensions/littlebits_small.jpg" alt="littleBits" />
                         </a>
                         <section class="description">
                             <p>Control littleBits creations</p>
@@ -342,7 +342,7 @@
                                 <h2>Make!Sense</h2>
                                 <p class="author">Stephen Lewis, Deqing Sun, Steven Holmes</p>
                             </header>
-                            <img src="images/extensions/makesense_small.png" />
+                            <img src="images/extensions/makesense_small.png" alt="Make!Sense" />
                         </a>
                         <section class="description">
                             <p>Sensor interface board and sensors</p>
@@ -359,7 +359,7 @@
                                 <h2>micro:bit</h2>
                                 <p class="author">Kreg Hanning</p>
                             </header>
-                            <img src="images/extensions/microbit_small.png" />
+                            <img src="images/extensions/microbit_small.png" alt="micro:bit" />
                         </a>
                         <section class="description">
                             <p>Control micro:bit over bluetooth</p>
@@ -376,7 +376,7 @@
                                 <h2>Poppy Ergo Jr.</h2>
                                 <p class="author">Stefania Druga &amp; Eesh Likhith</p>
                             </header>
-                            <img src="images/extensions/poppy_small.png" />
+                            <img src="images/extensions/poppy_small.png" alt="Poppy Ergo Jr." />
                         </a>
                         <section class="description">
                             <p>Control the Poppy Ergo Jr. robot</p>
@@ -393,7 +393,7 @@
                                 <h2>rb4s – A Controller For The RedBot</h2>
                                 <p class="author">Alan Yorinks</p>
                             </header>
-                            <img src="images/extensions/rb4s_small.png" />
+                            <img src="images/extensions/rb4s_small.png" alt="rb4s – A Controller For The RedBot" />
                         </a>
                         <section class="description">
                             <p>Control and Monitor a RedBot Robot</p>
@@ -410,7 +410,7 @@
                                 <h2>Roamer</h2>
                                 <p class="author">Kevin Rands, Dave Ewins, Dave Catlin</p>
                             </header>
-                            <img src="images/extensions/roamer_small.png" />
+                            <img src="images/extensions/roamer_small.png" alt="Roamer" />
                         </a>
                         <section class="description">
                             <p>Programming Roamer&reg; with ScratchX</p>
@@ -427,7 +427,7 @@
                                 <h2>Scratch3D</h2>
                                 <p class="author">Stephen Lewis, John Goodwin</p>
                             </header>
-                            <img src="images/extensions/scratch3d_small.png" />
+                            <img src="images/extensions/scratch3d_small.png" alt="Scratch3D" />
                         </a>
                         <section class="description">
                             <p>Fully 3D Environment</p>
@@ -444,7 +444,7 @@
                                 <h2>Sound Synthesizer</h2>
                                 <p class="author">Eric Rosenbaum</p>
                             </header>
-                            <img src="images/extensions/synth-extension-lg.png" />
+                            <img src="images/extensions/synth-extension-lg.png" alt="Sound Synthesizer" />
                         </a>
                         <section class="description">
                             <p>Synthesize sound effects and music</p>
@@ -461,7 +461,7 @@
                                 <h2>Spotify Music</h2>
                                 <p class="author">Eric Rosenbaum</p>
                             </header>
-                            <img src="images/extensions/spotify_large.png" />
+                            <img src="images/extensions/spotify_large.png" alt="Spotify Music" />
                         </a>
                         <section class="description">
                             <p>Animate and remix millions of songs!</p>
@@ -478,7 +478,7 @@
                                 <h2>Text to Speech</h2>
                                 <p class="author">Sayamindu Dasgupta</p>
                             </header>
-                            <img src="images/extensions/text-extension-sm.png" />
+                            <img src="images/extensions/text-extension-sm.png" alt="Text To Speech" />
                         </a>
                         <section class="description">
                             <p>Use Scratch to read text out loud</p>
@@ -495,7 +495,7 @@
                                 <h2>Thymio</h2>
                                 <p class="author">Mobsya</p>
                             </header>
-                            <img src="images/extensions/thymio_small.png" />
+                            <img src="images/extensions/thymio_small.png" alt="Thymio" />
                         </a>
                         <section class="description">
                             <p>Control the Thymio robot with Scratch!</p>
@@ -512,7 +512,7 @@
                                 <h2>Twitter</h2>
                                 <p class="author">Connor Hudson, Kreg Hanning</p>
                             </header>
-                            <img src="images/extensions/twitter-extension-sm.png" />
+                            <img src="images/extensions/twitter-extension-sm.png" alt="Twitter" />
                         </a>
                         <section class="description">
                             <p>Use Twitter in your projects!</p>
@@ -527,9 +527,9 @@
                         <a href="?url=http://verniersoftwaretechnology.github.io/scratch-vernier-go-extensions/go_motion_extension.js" data-action="load-url">
                             <header>
                                 <h2>Vernier Go!Motion</h2>
-                                <p class="author">Vernier Software & Technology</p>
+                                <p class="author">Vernier Software &amp; Technology</p>
                             </header>
-                            <img src="images/extensions/gomotion_small.jpg" />
+                            <img src="images/extensions/gomotion_small.jpg" alt="Vernier Go!Motion" />
                         </a>
                         <section class="description">
                             <p>Use position data in Scratch</p>
@@ -546,7 +546,7 @@
                                 <h2>Vernier Go!Temp</h2>
                                 <p class="author">Vernier Software & Technology</p>
                             </header>
-                            <img src="images/extensions/gotemp_small.jpg" />
+                            <img src="images/extensions/gotemp_small.jpg" alt="Vernier Go!Temp" />
                         </a>
                         <section class="description">
                             <p>Use temperature data in Scratch</p>
@@ -563,7 +563,7 @@
                                 <h2>Weather</h2>
                                 <p class="author">Sayamindu Dasgupta, Kreg Hanning</p>
                             </header>
-                            <img src="images/extensions/weather_small.png" />
+                            <img src="images/extensions/weather_small.png" alt="Weather" />
                         </a>
                         <section class="description">
                             <p>Access live weather information</p>
@@ -580,7 +580,7 @@
                                 <h2>Xi - Multi uC Interconnect</h2>
                                 <p class="author">Alan Yorinks</p>
                             </header>
-                            <img src="images/extensions/xi3_small.png" />
+                            <img src="images/extensions/xi3_small.png" alt="Xi - Multi uC Interconnect" />
                         </a>
                         <section class="description">
                             <p>Control for Arduino, <acronym title="Raspberry Pi">RPi</acronym> and <acronym title="BeagleBone Black">BBB</acronym></p>

--- a/index.html
+++ b/index.html
@@ -544,7 +544,7 @@
                         <a href="?url=http://verniersoftwaretechnology.github.io/scratch-vernier-go-extensions/go_temp_extension.js" data-action="load-url">
                             <header>
                                 <h2>Vernier Go!Temp</h2>
-                                <p class="author">Vernier Software & Technology</p>
+                                <p class="author">Vernier Software &amp; Technology</p>
                             </header>
                             <img src="images/extensions/gotemp_small.jpg" alt="Vernier Go!Temp" />
                         </a>

--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
                                 <h2>Intel&reg; RealSense&trade;</h2>
                                 <p class="author">Shachar Oz, Yaron Yanai, Yotam Salmon</p>
                             </header>
-                            <img src="images/extensions/realsense_small.png" alt="ischertechnik robots" />
+                            <img src="images/extensions/realsense_small.png" alt="Intel RealSense" />
                         </a>
                         <section class="description">
                             <p>Hand Gestures, face tracking, voice commands</p>

--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
                 <div>
                     <div>
                         <h2 class="logo-scratch">Scratch</h2>
-                        <p>With the Scratch programming language, you can create your own interactive stories, games, and animations &mdash; and share your creations with others in an online community. <a href="http://scratch.mit.edu">Take me to Scratch</a></p>
+                        <p>With the Scratch programming language, you can create your own interactive stories, games, and animations &mdash; and share your creations with others in an online community. <a href="https://scratch.mit.edu">Take me to Scratch</a></p>
                     </div>
                 </div>
                 <div>


### PR DESCRIPTION
Fixes #138

#### Changes
- Adds an alt attribute to all the extension thumbnails.
- Changes a scratch link to https and fixes two stray ``&``'s.

#### Tests 
I set up an environment to make sure I haven't broken anything, Everything works as expected.