### PR TITLE
Add PocketLab extension

### DIFF
--- a/index.html
+++ b/index.html
@@ -371,6 +371,24 @@
                         </section>
                     </li>
                     <li>
+                        <a href="?url=https://thepocketlab.github.io/ScratchX/pocketlab_extension.js" data-action="load-url">
+
+                            <header>
+                                <h2>PocketLab for Scratch</h2>
+                                <p class="author">The PocketLab by Myriad Sensors, Inc</p>
+                            </header>
+                            <img src="images/extensions/pocketlab_small.png" alt="pocketlab" />
+                        </a>
+                        <section class="description">
+                            <p>Real time PocketLab sensor data!</p>
+                            <a href="?url=https://thepocketlab.github.io/ScratchX/SpaceBlaster.sbx" data-action="load-url">Sample Project</a>
+                            <a href="http://www.thepocketlab.com/support/article/pocketlab-scratch-integration-beta" target="_blank">Documentation</a>
+                        </section>
+                        <section class="tags">
+                            <span class="tag hardware" title="Hardware Extension">Requires Hardware</span>
+                        </section>
+                    </li>
+                    <li>
                         <a href="https://eesh.github.io/scratch-test/">
                             <header>
                                 <h2>Poppy Ergo Jr.</h2>


### PR DESCRIPTION
This extension was approved a while ago. We were just waiting on a few assets for the ScratchX library page.