### PR TITLE
Update Github URLs for Vernier org

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,7 +541,7 @@
                         </section>
                     </li>
                     <li>
-                        <a href="?url=https://verniersoftwaretechnology.github.io/scratch-vernier-go-extensions/go_motion_extension.js" data-action="load-url">
+                        <a href="?url=https://vernierst.github.io/scratch-vernier-go-extensions/go_motion_extension.js" data-action="load-url">
                             <header>
                                 <h2>Vernier Go!Motion</h2>
                                 <p class="author">Vernier Software &amp; Technology</p>
@@ -550,15 +550,15 @@
                         </a>
                         <section class="description">
                             <p>Use position data in Scratch</p>
-                            <a href="?url=https://verniersoftwaretechnology.github.io/scratch-vernier-go-extensions/examples/SayMotion.sbx" data-action="load-url">Sample Project</a>
-                            <a href="https://verniersoftwaretechnology.github.io/scratch-vernier-go-extensions/" target="_blank">Documentation</a>
+                            <a href="?url=https://vernierst.github.io/scratch-vernier-go-extensions/examples/SayMotion.sbx" data-action="load-url">Sample Project</a>
+                            <a href="https://vernierst.github.io/scratch-vernier-go-extensions/" target="_blank">Documentation</a>
                         </section>
                         <section class="tags">
                             <span class="tag hardware" title="Hardware Extension">Requires Hardware</span>
                         </section>
                     </li>
                     <li>
-                        <a href="?url=https://verniersoftwaretechnology.github.io/scratch-vernier-go-extensions/go_temp_extension.js" data-action="load-url">
+                        <a href="?url=https://vernierst.github.io/scratch-vernier-go-extensions/go_temp_extension.js" data-action="load-url">
                             <header>
                                 <h2>Vernier Go!Temp</h2>
                                 <p class="author">Vernier Software &amp; Technology</p>
@@ -567,8 +567,8 @@
                         </a>
                         <section class="description">
                             <p>Use temperature data in Scratch</p>
-                            <a href="?url=https://verniersoftwaretechnology.github.io/scratch-vernier-go-extensions/examples/SayTemp.sbx" data-action="load-url">Sample Project</a>
-                            <a href="https://verniersoftwaretechnology.github.io/scratch-vernier-go-extensions/" target="_blank">Documentation</a>
+                            <a href="?url=https://vernierst.github.io/scratch-vernier-go-extensions/examples/SayTemp.sbx" data-action="load-url">Sample Project</a>
+                            <a href="https://vernierst.github.io/scratch-vernier-go-extensions/" target="_blank">Documentation</a>
                         </section>
                         <section class="tags">
                             <span class="tag hardware" title="Hardware Extension">Requires Hardware</span>


### PR DESCRIPTION
Vernier changed their Github organization name from verniersoftwaretechnology to vernierst. ScratchX extension links have been updated accordingly. All sample projects have been updated to point at the new URL and the crossdomain.xml has been verified.

This PR updates both the Vernier Go!Motion and Go!Temp extensions.